### PR TITLE
feat: add unit tets and fix password hashing RP-22

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -16,6 +16,6 @@ export const routes: Routes = [
   {path: 'product-detail/:id', component: ProductComponent },
   {path: 'product-list', component: ProductListPageComponent, canActivate: [AuthGuard]},
   {path: 'printer-management', component: PrinterManagementComponent, canActivate: [AuthGuard]},
-  {path: 'login', component: LoginComponent }
-
+  {path: 'login', component: LoginComponent },
+  {path: 'register', component: RegisterComponent }
 ];

--- a/src/app/register/register.component.html
+++ b/src/app/register/register.component.html
@@ -10,7 +10,7 @@
             <form [formGroup]="this.registerFormGroup">
               <div class="mb-3">
                 <label for="email" class="form-label">Email</label>
-                <input type="text" class="form-control" id="email" name="email" formControlName="email" (keyup.enter)="onSubmit()">
+                <input type="text" class="form-control" id="email" name="email" formControlName="email" (keyup.enter)="onSubmit()" required>
               </div>
               <div class="mb-3">
                 <label for="fname" class="form-label">Full Name</label>
@@ -26,7 +26,7 @@
               </div>
               <div class="mb-3">
                 <label for="password_conf" class="form-label">Password Again</label>
-                <input type="password_conf" class="form-control" id="password_conf" name="password_conf" formControlName="password_conf" (keyup.enter)="onSubmit()">
+                <input type="password" class="form-control" id="password_conf" name="password_conf" formControlName="password_conf" (keyup.enter)="onSubmit()">
               </div>
               <button type="submit" class="btn btn-primary" (click)="onSubmit()">Register</button>
             </form>
@@ -36,7 +36,7 @@
           The registration has been completed. Proceed to logging in.
         </div>
         <div *ngIf="this.registrationFailed" class="alert alert-danger" role="alert">
-          Registration failed. The email is already registered.
+          {{ errorMsg }}
         </div>
       </div>
     </div>

--- a/src/app/register/register.component.spec.ts
+++ b/src/app/register/register.component.spec.ts
@@ -1,10 +1,11 @@
-import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, flush, tick, waitForAsync } from '@angular/core/testing';
 import { RegisterComponent } from './register.component';
 import { ReactiveFormsModule, FormsModule, FormBuilder, Validators } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AuthService } from '../shared/services/auth.service';
 import { of, throwError } from 'rxjs';
+import { LoginComponent } from '../login/login.component';
 
 describe('RegisterComponent', () => {
   let component: RegisterComponent;
@@ -14,7 +15,8 @@ describe('RegisterComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule, FormsModule, HttpClientTestingModule, RouterTestingModule],
+      imports: [ReactiveFormsModule, FormsModule, HttpClientTestingModule, RouterTestingModule.withRoutes(
+        [{path: 'login', component: LoginComponent}])],
       providers: [AuthService]
     })
     .compileComponents();
@@ -74,6 +76,7 @@ describe('RegisterComponent', () => {
     tick();
     fixture.detectChanges();
     expect(component.registrationSuccess).toBeTrue();
+    flush();
   }));
 
 

--- a/src/app/register/register.component.spec.ts
+++ b/src/app/register/register.component.spec.ts
@@ -1,23 +1,147 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
 import { RegisterComponent } from './register.component';
+import { ReactiveFormsModule, FormsModule, FormBuilder, Validators } from '@angular/forms';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { AuthService } from '../shared/services/auth.service';
+import { of, throwError } from 'rxjs';
 
 describe('RegisterComponent', () => {
   let component: RegisterComponent;
   let fixture: ComponentFixture<RegisterComponent>;
+  let authService: AuthService;
+  let formBuilder: FormBuilder;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [RegisterComponent]
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, FormsModule, HttpClientTestingModule, RouterTestingModule],
+      providers: [AuthService]
     })
     .compileComponents();
-    
+
+    authService = TestBed.inject(AuthService);
+    formBuilder = TestBed.inject(FormBuilder);
+  }));
+
+  beforeEach(() => {
     fixture = TestBed.createComponent(RegisterComponent);
     component = fixture.componentInstance;
+    component.registerFormGroup = formBuilder.group({
+      email: ['person@example.org', [Validators.email, Validators.required]],
+      fname: ['Mr Example Persona', Validators.required],
+      address: ['1000 Examplistan, Sample St. 69420', Validators.required],
+      password: ['porejemplo123', [Validators.required, Validators.minLength(8)]],
+      password_conf: ['porejemplo123', [Validators.required, Validators.minLength(8)]]
+    });
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should initialize the form group', () => {
+    const formGroup = component.registerFormGroup;
+    expect(formGroup.contains('email')).toBeTruthy();
+    expect(formGroup.contains('fname')).toBeTruthy();
+    expect(formGroup.contains('address')).toBeTruthy();
+    expect(formGroup.contains('password')).toBeTruthy();
+    expect(formGroup.contains('password_conf')).toBeTruthy();
+  });
+
+  it('form invalid when empty', () => {
+    component.registerFormGroup = formBuilder.group({
+      email: ['', [Validators.email, Validators.required]],
+      fname: ['', Validators.required],
+      address: ['', Validators.required],
+      password: ['', [Validators.required, Validators.minLength(8)]],
+      password_conf: ['', [Validators.required, Validators.minLength(8)]]
+    });
+    expect(component.registerFormGroup.valid).toBeFalsy();
+  });
+
+  it('should set registrationFailed to true on submit failure', fakeAsync(() => {
+    spyOn(authService, 'register').and.returnValue(throwError(() => new Error('Failed')));
+    component.onSubmit();
+    tick();
+    fixture.detectChanges();
+    expect(component.registrationFailed).toBeTrue();
+  }));
+
+  it('should set registrationSuccess to true on submit success', fakeAsync(() => {
+    spyOn(authService, 'register').and.returnValue(of({ success: true }));
+    component.onSubmit();
+    tick();
+    fixture.detectChanges();
+    expect(component.registrationSuccess).toBeTrue();
+  }));
+
+
+  it('should not be able to register if email is empty', () => {
+    spyOn(authService, 'register');
+    component.registerFormGroup.controls['email'].setValue('');
+    component.onSubmit();
+    expect(authService.register).not.toHaveBeenCalled();
+    expect(component.errorMsg).toEqual('Email is invalid.');
+  });
+
+  it('should not be able to register if email is not an email', () => {
+    spyOn(authService, 'register');
+    component.registerFormGroup.controls['email'].setValue('not_an_email');
+    component.onSubmit();
+    expect(authService.register).not.toHaveBeenCalled();
+    expect(component.errorMsg).toEqual('Email is invalid.');
+  });
+
+  it('should not be able to register if full name is empty', () => {
+    spyOn(authService, 'register');
+    component.registerFormGroup.controls['fname'].setValue('');
+    component.onSubmit();
+    expect(authService.register).not.toHaveBeenCalled();
+    expect(component.errorMsg).toEqual('Full Name is empty.');
+  });
+
+  it('should not be able to register if billing address is empty', () => {
+    spyOn(authService, 'register');
+    component.registerFormGroup.controls['address'].setValue('');
+    component.onSubmit();
+    expect(authService.register).not.toHaveBeenCalled();
+    expect(component.errorMsg).toEqual('Billing Address is empty.');
+  });
+
+  it('should not be able to register if password is invalid', () => {
+    spyOn(authService, 'register');
+    component.registerFormGroup.controls['password'].setValue('less8');
+    component.onSubmit();
+    expect(authService.register).not.toHaveBeenCalled();
+    expect(component.errorMsg).toEqual('Password is invalid.');
+  });
+
+  it('should not be able to register if password is empty', () => {
+    spyOn(authService, 'register');
+    component.registerFormGroup.controls['password'].setValue('');
+    component.onSubmit();
+    expect(authService.register).not.toHaveBeenCalled();
+    expect(component.errorMsg).toEqual('Password is invalid.');
+  });
+
+  it('should not be able to register if password confirmation is empty', () => {
+    spyOn(authService, 'register');
+    component.registerFormGroup.controls['password'].setValue('a_valid_password');
+    component.registerFormGroup.controls['password_conf'].setValue('');
+    component.onSubmit();
+    expect(authService.register).not.toHaveBeenCalled();
+    expect(component.errorMsg).toEqual('Passwords do not match.');
+  });
+
+  it('should not be able to register if passwords do not match', () => {
+    spyOn(authService, 'register');
+    component.registerFormGroup.controls['password'].setValue('a_valid_password_1');
+    component.registerFormGroup.controls['password_conf'].setValue('a_valid_password_"');
+    component.onSubmit();
+    expect(authService.register).not.toHaveBeenCalled();
+    expect(component.errorMsg).toEqual('Passwords do not match.');
+  });
+
+
 });

--- a/src/app/register/register.component.ts
+++ b/src/app/register/register.component.ts
@@ -70,7 +70,7 @@ export class RegisterComponent {
           roleId: 2,
           roleName: ""
         },
-        password_hash: this.registerFormGroup.getRawValue().password
+        passwordHash: this.registerFormGroup.getRawValue().password
       }
       console.log(registeringUser);
       this.authService.register(registeringUser).subscribe(

--- a/src/app/register/register.component.ts
+++ b/src/app/register/register.component.ts
@@ -77,6 +77,9 @@ export class RegisterComponent {
         data => {
           if (data.success) {
             this.registrationSuccess = true;
+            setTimeout(() => {
+              this.router.navigate(['login']);
+            }, 3000);
           }
         },
         error => {

--- a/src/app/register/register.component.ts
+++ b/src/app/register/register.component.ts
@@ -62,7 +62,7 @@ export class RegisterComponent {
       this.registrationFailed = true;
       return;
     } else {
-      const registeringUser: User = {
+      const registeringUser = {
         userId: null,
         email: this.registerFormGroup.getRawValue().email,
         billingAddress: this.registerFormGroup.getRawValue().fname,
@@ -70,6 +70,7 @@ export class RegisterComponent {
           roleId: 2,
           roleName: ""
         },
+        password_hash: this.registerFormGroup.getRawValue().password
       }
       console.log(registeringUser);
       this.authService.register(registeringUser).subscribe(
@@ -81,6 +82,7 @@ export class RegisterComponent {
         error => {
           console.log(error);
           this.registrationFailed = true;
+          this.errorMsg = "Internal error."
           console.log(this.registrationFailed);
         }
       );

--- a/src/app/register/register.component.ts
+++ b/src/app/register/register.component.ts
@@ -18,24 +18,49 @@ export class RegisterComponent {
 
   public registrationSuccess: boolean = false;
   public registrationFailed: boolean = false;
+  public errorMsg: string = "";
 
-  public readonly registerFormGroup: FormGroup;
+  public registerFormGroup: FormGroup;
 
   constructor(private readonly formBuilder: FormBuilder, private authService: AuthService, private router: Router) {
     this.registerFormGroup = this.formBuilder.group({
-      email: ['', Validators.email],
+      email: ['', [Validators.required, Validators.pattern('^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+[.][a-zA-Z0-9-.]+$')]],
       fname: ['', Validators.required],
-      address: ['', Validators.required],
-      password: ['', Validators.required],
-      password_conf: ['', Validators.required]
+      address: ['', [Validators.required, Validators.minLength(1)]],
+      password: ['', [Validators.required, Validators.minLength(8)]],
+      password_conf: ['', [Validators.required, Validators.minLength(8)]]
     });
   }
 
   onSubmit() {
     this.registrationFailed = false;
     this.registrationSuccess = false;
+    
     if (this.registerFormGroup.invalid) {
-      alert('Invalid input');
+      console.log(this.registerFormGroup)
+      switch ("INVALID") {
+        case this.registerFormGroup.controls['email'].status:
+          this.errorMsg = "Email is invalid.";
+          break;
+        case this.registerFormGroup.controls['fname'].status:
+          this.errorMsg = "Full Name is empty.";
+          break;
+        case this.registerFormGroup.controls['address'].status:
+          this.errorMsg = "Billing Address is empty.";
+          break;
+        case this.registerFormGroup.controls['password'].status:
+          this.errorMsg = "Password is invalid.";
+          break;
+        case this.registerFormGroup.controls['password_conf'].status:
+          this.errorMsg = "Passwords do not match.";
+          break;
+      }
+      
+      this.registrationFailed = true;
+    } else if (this.registerFormGroup.getRawValue().password !== this.registerFormGroup.getRawValue().password_conf) {
+      this.errorMsg = "Passwords do not match."
+      this.registrationFailed = true;
+      return;
     } else {
       const registeringUser: User = {
         userId: null,
@@ -45,8 +70,6 @@ export class RegisterComponent {
           roleId: 2,
           roleName: ""
         },
-        // including this is probably a VERY BAD IDEA
-        passwordHash: hashSync(this.registerFormGroup.getRawValue().password)
       }
       console.log(registeringUser);
       this.authService.register(registeringUser).subscribe(
@@ -62,5 +85,10 @@ export class RegisterComponent {
         }
       );
     }
+  }
+
+  validateEmail(): boolean {
+    console.log("asdasd")
+    return !new RegExp("/^[a-zA-Z0-9. _%+-]+@[a-zA-Z0-9. -]+\\. [a-zA-Z]{2,}$/").test(this.registerFormGroup.getRawValue()["email"]);
   }
 }

--- a/src/app/shared/interfaces/user.ts
+++ b/src/app/shared/interfaces/user.ts
@@ -5,5 +5,4 @@ export interface User {
     email: string;
     billingAddress: string;
     role: Role | null;
-    passwordHash: string;
 }


### PR DESCRIPTION
## Description
13 new unit tests have been added. The unused password_hash field has been revamped, and is used for sending the user password itself for backend-side hashing.

## Related Issue(s)
RP-22

## Type of Change
Replace the whitespace with an `x` in the boxes that apply

- [x] Bugfix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please describe):

## Checklist:
Go over all the following points, and replace the whitespace with an `x` in all the boxes that apply.

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
