### PR TITLE
feat: change form used to reactive and auth guard RP-63

### DIFF
--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -14,11 +14,11 @@ export class AuthGuard implements CanActivate {
     next: ActivatedRouteSnapshot,
     state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
     
-    if (this.authService.isLoggedIn()) {
+    if (this.authService.isLoggedIn() && this.authService.getMyRole()?.roleId === 1) {
       return true; // Allow access to the route
     } else {
       // Redirect to the login page
-      return this.router.createUrlTree(['/login']);
+      return this.router.createUrlTree(['/']);
     }
   }
 }

--- a/src/app/printer-management/printer-management.component.html
+++ b/src/app/printer-management/printer-management.component.html
@@ -39,23 +39,26 @@
         </button>
       </div>
       <div class="modal-body">
-        <form (ngSubmit)="currentPrinter.printer_id ? updatePrinter(currentPrinter) : addPrinter(currentPrinter)">
+        <form [formGroup]="this.printerFormGroup">
           <div class="form-group">
             <label for="printer-name" class="col-form-label">Printer Name:</label>
-            <input type="text" class="form-control" id="printer-name" [(ngModel)]="currentPrinter.name" name="name" required>
+            <input type="text" class="form-control" id="printer-name" formControlName="printerName" name="name" required>
           </div>
           <div class="form-group mb-3">
             <label class="form-label">IP Address</label>
-            <input type="text" class="form-control" [(ngModel)]="currentPrinter.ip_addr" name="ip_addr" required>
-            <small class="text-muted">e.g. "123.123.123.123"</small>
+            <input type="text" class="form-control" name="ip_addr" formControlName="ipAddress" required>
+            <small class="text-muted">e.g. "192.168.1.100"</small>
           </div>
           <div class="form-group">
             <label for="printer-apikey" class="col-form-label">API Key:</label>
-            <input type="text" class="form-control" id="printer-apikey" [(ngModel)]="currentPrinter.apikey" name="apikey" required>
+            <input type="text" class="form-control" id="printer-apikey" name="apikey" formControlName="apiKey" required>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-secondary" (click)="toggleModal(false)">Close</button>
-            <button type="submit" class="btn btn-primary">{{ currentPrinter.printer_id ? 'Update Printer' : 'Add Printer' }}</button>
+            <button type="submit" class="btn btn-primary" (click)="onSubmit()">{{ currentPrinterId ? 'Update Printer' : 'Add Printer' }}</button>
+          </div>
+          <div *ngIf="errorMsg" class="alert alert-danger" role="alert">
+            {{ errorMsg }}
           </div>
         </form>
       </div>

--- a/src/app/shared/interfaces/printer.ts
+++ b/src/app/shared/interfaces/printer.ts
@@ -1,6 +1,6 @@
 export class Printer {
   printer_id?: number;
-  name?: string;
+  name?: string | undefined;
   location?: string;
   ip_addr?: string;
   apikey?: string;


### PR DESCRIPTION
## Description
Added auth guard so that only MaaS Owner role can open the page. Rewritten the form to use Reactive Forms. Added new unit tests.

## Related Issue(s)
RP-63

## Type of Change
Replace the whitespace with an `x` in the boxes that apply

- [x] Bugfix
- [ ] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other (please describe):

## Checklist:
Go over all the following points, and replace the whitespace with an `x` in all the boxes that apply.

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
